### PR TITLE
Add Telegram bot for OpenAI request pricing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env and fill in your Telegram bot token
+BOT_TOKEN=your_telegram_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY bot.py ./
+
+CMD ["python", "bot.py"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Telegram OpenAI Pricing Bot
+
+This bot calculates the price of OpenAI requests in Russian rubles.
+
+## Commands
+
+- `/set_prices <input_price_usd> <output_price_usd>` — set prices for input and output tokens in USD per 1M tokens.
+- `/set_rate <usd_to_rub>` — set the USD to RUB exchange rate.
+- `/calc <input_tokens> <output_tokens>` — calculate cost in RUB.
+
+## Local run
+
+```bash
+pip install -r requirements.txt
+BOT_TOKEN=<your token> python bot.py
+```
+
+## Docker
+
+1. Copy `.env.example` to `.env` and put your Telegram bot token there.
+2. Start the bot:
+
+```bash
+docker-compose up --build
+```

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,82 @@
+import os
+import asyncio
+from collections import defaultdict
+from telegram import Update
+from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
+
+# Хранение настроек для каждого пользователя
+user_settings = defaultdict(lambda: {"input_price": 0.0, "output_price": 0.0, "rate": 0.0})
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Отправляет инструкции пользователю."""
+    text = (
+        "Задайте цены командой /set_prices <цена_ввода_usd> <цена_вывода_usd>\n"
+        "Установите курс USD→RUB командой /set_rate <курс>\n"
+        "Рассчитайте стоимость командой /calc <токены_ввода> <токены_вывода>"
+    )
+    await update.message.reply_text(text)
+
+async def set_prices(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if len(context.args) != 2:
+        await update.message.reply_text("Использование: /set_prices <цена_ввода_usd> <цена_вывода_usd>")
+        return
+    try:
+        input_price = float(context.args[0])
+        output_price = float(context.args[1])
+    except ValueError:
+        await update.message.reply_text("Цены должны быть числами")
+        return
+    data = user_settings[update.effective_user.id]
+    data["input_price"] = input_price
+    data["output_price"] = output_price
+    await update.message.reply_text(
+        f"Цены установлены: ввод {input_price} USD/1M, вывод {output_price} USD/1M"
+    )
+
+async def set_rate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if len(context.args) != 1:
+        await update.message.reply_text("Использование: /set_rate <курс_usd_к_rub>")
+        return
+    try:
+        rate = float(context.args[0])
+    except ValueError:
+        await update.message.reply_text("Курс должен быть числом")
+        return
+    data = user_settings[update.effective_user.id]
+    data["rate"] = rate
+    await update.message.reply_text(f"Курс установлен: {rate} руб. за 1 USD")
+
+async def calc(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if len(context.args) != 2:
+        await update.message.reply_text("Использование: /calc <токены_ввода> <токены_вывода>")
+        return
+    try:
+        input_tokens = int(context.args[0])
+        output_tokens = int(context.args[1])
+    except ValueError:
+        await update.message.reply_text("Количество токенов должно быть целым числом")
+        return
+    data = user_settings[update.effective_user.id]
+    if data["rate"] == 0 or (data["input_price"] == 0 and data["output_price"] == 0):
+        await update.message.reply_text(
+            "Сначала задайте цены /set_prices и курс /set_rate"
+        )
+        return
+    input_cost_usd = input_tokens * data["input_price"] / 1_000_000
+    output_cost_usd = output_tokens * data["output_price"] / 1_000_000
+    total_rub = (input_cost_usd + output_cost_usd) * data["rate"]
+    await update.message.reply_text(f"Стоимость: {total_rub:.2f} руб.")
+
+async def main() -> None:
+    token = os.environ.get("BOT_TOKEN")
+    if not token:
+        raise RuntimeError("BOT_TOKEN environment variable not set")
+    app = ApplicationBuilder().token(token).build()
+    app.add_handler(CommandHandler("start", start))
+    app.add_handler(CommandHandler("set_prices", set_prices))
+    app.add_handler(CommandHandler("set_rate", set_rate))
+    app.add_handler(CommandHandler("calc", calc))
+    await app.run_polling()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  bot:
+    build: .
+    environment:
+      - BOT_TOKEN=${BOT_TOKEN}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot==20.3


### PR DESCRIPTION
## Summary
- implement Telegram bot that calculates OpenAI request cost in RUB based on user-set token prices and exchange rate
- add Dockerfile and docker-compose for easy deployment
- document usage and environment configuration
- localize bot responses to Russian and retain per-user settings

## Testing
- `python -m py_compile bot.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbc838be1c8331bb0b9cdc01842ecb